### PR TITLE
Footer covers table of contents tree

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -61,6 +61,7 @@ html, body {
 .toc {
     overflow-x: hidden;
     padding-left: 10px;
+    margin-bottom: 65px;
 }
 
 .toc .nav > li > a {


### PR DESCRIPTION
Sometimes the "Back to top" footer can hide topics from the table of contents:

![image](https://user-images.githubusercontent.com/743918/47651851-fceb8d00-db8c-11e8-810a-2054f9edb0da.png)

![image](https://user-images.githubusercontent.com/743918/47651868-0d036c80-db8d-11e8-91a4-52bb947fc97a.png)

This fixes the issue by adding a bottom margin to the table of contents panel:

![image](https://user-images.githubusercontent.com/743918/47652011-72eff400-db8d-11e8-84a9-af00df816351.png)
